### PR TITLE
Explanation for contents of harmonic analysis output files

### DIFF
--- a/docs/packages/omc3/about.md
+++ b/docs/packages/omc3/about.md
@@ -16,7 +16,7 @@ The `omc3` package serves the following purposes:
 - Providing a convenient wrapper to effortlessly run `MAD-X` jobs.
 
 For installation instructions and detailed content see the [getting started guide](getting_started.md).
-For a step by step walk-through of an `omc3` workflow, see the [workflow guide](workflow.md).
+For a step by step walk-through of an `omc3` analysis workflow, see the [workflow guide](analysis.md).
 
 ## Changelog
 

--- a/docs/packages/omc3/analysis.md
+++ b/docs/packages/omc3/analysis.md
@@ -770,7 +770,7 @@ trackone.sdds.bad_bpms_y	trackone.sdds.liny
     To use these, refer to the [Plot Spectrum][plot_spectrum] API documentation.
 
 ??? question "Column Nomenclature"
-    TODO: add a reference with the meaning of each column in the important files (the `.lin*` ones)
+    T
 
 ## Optics Analysis
 

--- a/docs/packages/omc3/analysis.md
+++ b/docs/packages/omc3/analysis.md
@@ -773,8 +773,8 @@ trackone.sdds.bad_bpms_y	trackone.sdds.liny
     The `*.amps[xy]`, `*.freqs[xy]` and `*.lin[xy]` files in the harmonic analysis output are **TFS** files.
 
     The `*.freqs[xy]` files contain for each BPM in column format the frequencies of the resonance lines detected in the spectrum, for respectively the horizontal (`.freqsx`) and vertical (`.freqsy`) planes while the `*.amps[xy]` files contain the amplitudes of said resonance lines.
-    This means in the column of a given BPM, the `nth` value in the `.amps[xy]` file corresponds to the amplitude of the resonance line located at the frequency given by the `nth` value in the column of the same name in the `.freqs[xy]` file.
-    Plotting the spectrum from these files would simply go as:
+    This means in the column of a given BPM, the `nth` row in the `.amps[xy]` file corresponds to the amplitude of the resonance line located at the frequency given by the `nth` row in the column of the same name in the `.freqs[xy]` file.
+    For illustration purposes, simplistic plotting of the horizontal spectrum (without the spectrum plotter mentioned above) from these files would go as:
     ```python
     import tfs
     import matplotlib.pyplot as plt
@@ -787,20 +787,19 @@ trackone.sdds.bad_bpms_y	trackone.sdds.liny
             plt.plot(freqsx[bpm], ampsx[bpm], ".-") 
             # plt.stem(freqsx[bpm], ampsx[bpm])  # would be more accurate but might stress your system
 
-    plt.xlim(0, 0.5)
-    plt.xlabel(r"$Q_x$")
-    plt.ylabel("Amplitude")
-    plt.title("Horizontal Spectrum")
+    plt.setp(plt.gca(), xlabel=r"$Q_x$", ylabel="Amplitude", title="Horizontal Spectrum", xlim=(0, 0.5))
     ```
 
     The `*.lin[xy]` files contain various data (in columns) computed for each BPM (in rows) as some summary information.
     Some column names are explicit: `BPM_RES` contains the determined BPM resolution, `CO` the closed orbit value at said BPM and `PK2PK` is the peak-to-peak value of oscillations registered by the given BPM.
     `TUNE[XY]`, `AMP[XY]` and `MU[XY]` are the detected tune, the amplitude of the tune line and the phase of the tune line for said BPM, respectively.
     
-    Some columns are named less explicitely but important for later optics calculations.
-    In the `.linx` file `FREQ01`, `AMP01` and `PHASE01` are respectively the frequency of the main vertical tune line in the horizontal spectrum, the ratio of this line to the main horizontal line and the phase of this line.
+    The other columns describe the phase (`PHASE`), amplitude ratio (`AMP`) and frequency (`FREQ`) of the line identified by the number in the column name, where underscores represent a minus sign.
+    Therefore, in the `.linx` file `FREQ01`, `AMP01` and `PHASE01` are respectively the frequency of the main vertical tune line in the horizontal spectrum, the ratio of this line's amplitude to that of the main horizontal line and the phase of this line.
     The equivalent columns in the `.liny` file are `FREQ10`, `AMP10` and `PHASE10`.
-    `FREQ02`, `AMP02` and `PHASE02` work similarly for the second vertical line in the horizontal spectrum, and so on.
+
+    Generally speaking, the frequency and amplitude of higher order lines is calculated using $m \cdot Q_x + n \cdot Q_y$  so `FREQ1_3` corresponds to $m = 1$ and $n = -3$ which is a decapolar line ($|m| + |n| = 4)$.
+    For more information, [this paper on normal forms][normal_forms]{target=_blank} is a good resource.
 
 ## Optics Analysis
 
@@ -872,6 +871,7 @@ interaction_point_y.tfs	    phase_x.tfs
 [sdds]: https://ops.aps.anl.gov/SDDSIntroTalk/slides.html
 [tbt_converter]: https://pylhc.github.io/omc3/entrypoints/other.html#tbt-converter
 [plot_spectrum]: https://pylhc.github.io/omc3/entrypoints/plotting.html#plot-spectrum
+[normal_forms]: https://cds.cern.ch/record/333077/files/p93.pdf
 [hole_in_one]: https://pylhc.github.io/omc3/entrypoints/analysis.html#omc3.hole_in_one.hole_in_one_entrypoint
 [new_machine_guide]: know_how.md#how-to-create-files-for-your-file-accelerator
 [model_creator]: https://pylhc.github.io/omc3/entrypoints/other.html#model-creator

--- a/docs/packages/omc3/analysis.md
+++ b/docs/packages/omc3/analysis.md
@@ -770,7 +770,37 @@ trackone.sdds.bad_bpms_y	trackone.sdds.liny
     To use these, refer to the [Plot Spectrum][plot_spectrum] API documentation.
 
 ??? question "Column Nomenclature"
-    T
+    The `*.amps[xy]`, `*.freqs[xy]` and `*.lin[xy]` files in the harmonic analysis output are **TFS** files.
+
+    The `*.freqs[xy]` files contain for each BPM in column format the frequencies of the resonance lines detected in the spectrum, for respectively the horizontal (`.freqsx`) and vertical (`.freqsy`) planes while the `*.amps[xy]` files contain the amplitudes of said resonance lines.
+    This means in the column of a given BPM, the `nth` value in the `.amps[xy]` file corresponds to the amplitude of the resonance line located at the frequency given by the `nth` value in the column of the same name in the `.freqs[xy]` file.
+    Plotting the spectrum from these files would simply go as:
+    ```python
+    import tfs
+    import matplotlib.pyplot as plt
+
+    ampsx = tfs.read("harpy_output/trackone.sdds.ampsx")
+    freqsx = tfs.read("harpy_output/trackone.sdds.freqsx")
+
+    for bpm in ampsx.columns:
+        if bpm in freqsx.columns:  # safety check but no reason it wouldn't be there
+            plt.plot(freqsx[bpm], ampsx[bpm], ".-") 
+            # plt.stem(freqsx[bpm], ampsx[bpm])  # would be more accurate but might stress your system
+
+    plt.xlim(0, 0.5)
+    plt.xlabel(r"$Q_x$")
+    plt.ylabel("Amplitude")
+    plt.title("Horizontal Spectrum")
+    ```
+
+    The `*.lin[xy]` files contain various data (in columns) computed for each BPM (in rows) as some summary information.
+    Some column names are explicit: `BPM_RES` contains the determined BPM resolution, `CO` the closed orbit value at said BPM and `PK2PK` is the peak-to-peak value of oscillations registered by the given BPM.
+    `TUNE[XY]`, `AMP[XY]` and `MU[XY]` are the detected tune, the amplitude of the tune line and the phase of the tune line for said BPM, respectively.
+    
+    Some columns are named less explicitely but important for later optics calculations.
+    In the `.linx` file `FREQ01`, `AMP01` and `PHASE01` are respectively the frequency of the main vertical tune line in the horizontal spectrum, the ratio of this line to the main horizontal line and the phase of this line.
+    The equivalent columns in the `.liny` file are `FREQ10`, `AMP10` and `PHASE10`.
+    `FREQ02`, `AMP02` and `PHASE02` work similarly for the second vertical line in the horizontal spectrum, and so on.
 
 ## Optics Analysis
 

--- a/docs/packages/omc3/getting_started.md
+++ b/docs/packages/omc3/getting_started.md
@@ -49,4 +49,4 @@ Other general utility scripts are in `/omc3/scripts` module:
 - `write_madx_macros.py` to generate `MAD-X` tracking macros with observation points from a twiss file.
 - `merge_kmod_results.py` to merge lsa_results files created by kmod, and add the luminosity imbalance if the 4 needed IP/Beam files combination are present.
 
-A typical analysis workflow with `omc3` is described in the [next page](workflow.md).
+A typical analysis workflow with `omc3` is described in the [next page](analysis.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,7 +114,7 @@ nav:
     - omc3:
       - About omc3: packages/omc3/about.md
       - Getting Started: packages/omc3/getting_started.md
-      - Workflow: packages/omc3/workflow.md
+      - Analysis: packages/omc3/analysis.md
       - Know-How: packages/omc3/know_how.md
       - ↪ On Github: https://github.com/pylhc/omc3
     - PyLHC: 


### PR DESCRIPTION
This is the small block explaning the contents of the files output by `harpy` that was missing in the `omc3` Worfklow page (now renamed Analysis).

If someone knows what the remaining columns mean (`FREQ1_3` etc) please contribute!