### PR TITLE
Ecosystem install instructions updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,203 @@
-# IntelliJ project files
-.idea
-*.iml
-out
-gen
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+doc_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/*
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### macOS template
 # General
 .DS_Store
 .AppleDouble
@@ -11,7 +205,6 @@ gen
 
 # Icon must end with two \r
 Icon
-
 
 # Thumbnails
 ._*
@@ -32,37 +225,27 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
-# Windows thumbnail cache files
-Thumbs.db
-Thumbs.db:encryptable
-ehthumbs.db
-ehthumbs_vista.db
+### JupyterNotebooks template
+# gitignore template for Jupyter Notebooks
+# website: http://jupyter.org/
 
-# Dump file
-*.stackdump
+.ipynb_checkpoints
+*/.ipynb_checkpoints/*
 
-# Folder config file
-[Dd]esktop.ini
+# Remove previous ipynb_checkpoints
+#   git rm -r .ipynb_checkpoints/
+#
 
-# Recycle Bin used on file shares
-$RECYCLE.BIN/
+# VSCode
+.vscode
+.vscode/
 
-# Windows Installer files
-*.cab
-*.msi
-*.msix
-*.msm
-*.msp
+# Neovim
+.nvimlog
 
-# Windows shortcuts
-*.lnk
-
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-*.code-workspace
-
-# Local History for Visual Studio Code
-.history/
+/.idea/codeStyles/codeStyleConfig.xml
+/.idea/misc.xml
+/.idea/modules.xml
+/.idea/inspectionProfiles/profiles_settings.xml
+/.idea/vcs.xml
+/.idea/PyhDToolkit.iml

--- a/docs/packages/omc3/about.md
+++ b/docs/packages/omc3/about.md
@@ -14,9 +14,8 @@ Installation is easily done via pip:
 python -m pip install omc3
 ```
 
-Additionally, some features require access to the CERN GPN and require CERN-specific dependencies.
-Those are installable from the CERN `Acc-Py` index through the `cern` extra.
-One can install from the CERN network or by providing the `index-url`:
+Additionally, some features require access to the CERN Technical Network and require CERN-specific dependencies.
+Those are installable from the CERN `Acc-Py` index through the `cern` extra, and can be installed from the CERN network or by providing the `index-url`:
 ```bash
 python -m pip install --index-url http://acc-py-repo.cern.ch:8081/repository/vr-py-releases/simple --trusted-host acc-py-repo.cern.ch "omc3[cern]"
 ```

--- a/docs/packages/omc3/about.md
+++ b/docs/packages/omc3/about.md
@@ -7,6 +7,20 @@ The `omc3` repository is the new version of our codes, refactored and rewritten 
     This section acts as a general documentation and guide to using the `omc3` package.
     The package's source can be found on [Github][omc3_gh]{target=_blank} and its API documentation can be found at the [following link][omc3_doc]{target=_blank}.
 
+## Installing
+
+Installation is easily done via pip:
+```bash
+pip install omc3
+```
+
+Additionally, some features require access to the CERN GPN and require CERN-specific dependencies.
+Those are installable from the CERN `Acc-Py` index through the `cern` extra.
+One can install from the CERN network or by providing the `index-url`:
+```bash
+pip install --index-url http://acc-py-repo.cern.ch:8081/repository/vr-py-releases/simple --trusted-host acc-py-repo.cern.ch "omc3[cern]"
+```
+
 ## What to expect
 
 The `omc3` package serves the following purposes:
@@ -17,10 +31,6 @@ The `omc3` package serves the following purposes:
 
 For installation instructions and detailed content see the [getting started guide](getting_started.md).
 For a step by step walk-through of an `omc3` analysis workflow, see the [workflow guide](analysis.md).
-
-## Changelog
-
-A changelog file is made available in the Github repository, at the following [link][omc3_changelog]{target=_blank}.
 
 ## License
 

--- a/docs/packages/omc3/about.md
+++ b/docs/packages/omc3/about.md
@@ -11,14 +11,14 @@ The `omc3` repository is the new version of our codes, refactored and rewritten 
 
 Installation is easily done via pip:
 ```bash
-pip install omc3
+python -m pip install omc3
 ```
 
 Additionally, some features require access to the CERN GPN and require CERN-specific dependencies.
 Those are installable from the CERN `Acc-Py` index through the `cern` extra.
 One can install from the CERN network or by providing the `index-url`:
 ```bash
-pip install --index-url http://acc-py-repo.cern.ch:8081/repository/vr-py-releases/simple --trusted-host acc-py-repo.cern.ch "omc3[cern]"
+python -m pip install --index-url http://acc-py-repo.cern.ch:8081/repository/vr-py-releases/simple --trusted-host acc-py-repo.cern.ch "omc3[cern]"
 ```
 
 ## What to expect

--- a/docs/packages/omc3/about.md
+++ b/docs/packages/omc3/about.md
@@ -24,7 +24,7 @@ A changelog file is made available in the Github repository, at the following [l
 
 ## License
 
-This software is licensed under the GNU GPLv3 License, see [License][license]{target=_blank}.
+This software is licensed under the `MIT` License, see [License][license]{target=_blank}.
 
 ## Authors
 

--- a/docs/packages/pylhc/about.md
+++ b/docs/packages/pylhc/about.md
@@ -9,6 +9,7 @@ It provides tools which can be useful for working with accelerators, but are not
 - [*Machine Settings Info*](machine_settings_info.md) - Prints an overview over the machine settings at a given time.
 - [*BSRT Logger* and *BSRT Analysis*](bsrt.md) - Saves data coming straight from LHC BSRT FESA class and allows subsequent analysis.
 - [*BPM Calibration*](bpm_calibration.md) - Script to compute the calibration factors for the LHC BPMs.
+- [*IR NonLinear RDT Correction*](irnl_correction.md) - Script to compute RDT correction in the (HL)LHC IRs including feed-down effects.
 
 ## Documentation
 
@@ -16,24 +17,19 @@ It provides tools which can be useful for working with accelerators, but are not
 
 ## Getting Started
 
-This  package is `Python 3.7+` compatible, but not yet deployed to PyPI.
-The best way to install is through pip and VCS:
+This  package is `Python 3.7+` compatible, and can be installed through `pip`:
 
 ```bash
-git clone https://github.com/pylhc/PyLHC
-pip install /path/to/PyLHC
-```
-
-Or simply from the online master branch, which is stable:
-
-```bash
-pip install git+https://github.com/pylhc/PyLHC.git#egg=pylhc
+python -m pip install pylhc
 ```
 
 After installing, codes can be run with either `python -m pylhc.SCRIPT --FLAG ARGUMENT` or calling path to the `.py` file directly.
 
-Note: some of the scripts access functionality only available on the CERN Technical Network.
-To use those, you should make sure to install the relevant extra dependencies with `pip install path/to/Pylhc[tech]`.
+Note: similarly to `omc3`, some of the scripts access functionality only available on the CERN Technical Network.
+To use those, you should make sure to install the relevant extra dependencies with:
+```bash
+python -m pip install --index-url http://acc-py-repo.cern.ch:8081/repository/vr-py-releases/simple --trusted-host acc-py-repo.cern.ch "pylhc[cern]"`.
+```
 
 [repo]: https://github.com/pylhc/PyLHC
 [documentation]: https://pylhc.github.io/PyLHC/

--- a/docs/packages/pylhcsubmitter/about.md
+++ b/docs/packages/pylhcsubmitter/about.md
@@ -13,19 +13,23 @@
 
 ## Getting Started
 
-This package is `Python 3.7+` compatible and deployed to PyPI.
-The best way to install is through pip:
+!!! warning "Package Availability"
+    As it requires `HTCondor` bindings, this package is unavailable on Windows.
+    The package is available on:
+      - `Linux` through `PyPI`.
+      - `Linux` and `macOS` through `conda-forge`.
 
+Installation is easily done via pip:
 ```bash
-pip install pylhc-submitter
+python -m pip install pylhc-submitter
 ```
 
-Alternatively, a local copy of the repository can be obtained and installed as such:
-
+One can also install in a conda environment via the conda-forge channel with:
 ```bash
-git clone https://github.com/pylhc/submitter
-pip install /path/to/submitter
+conda install -c conda-forge pylhc_submitter
 ```
+
+After installing, scripts can be run with either python -m pylhc_submitter.SCRIPT --FLAG ARGUMENT or by calling the Python files directly.
 
 After installing, codes can be run with either
 


### PR DESCRIPTION
Updates some details for the python ecosystem packages' about pages:
- license information
- installation instructions
- details about the `cern` extra dependencies and installing then from the `Acc-Py` index