### PR TITLE
fixed links

### DIFF
--- a/docs/guis/about.md
+++ b/docs/guis/about.md
@@ -71,13 +71,13 @@ If you encounter a complaint about `Java` being too old, try using `/mcr/bin/jws
 
 !!! failure
     ```bash
-    javaws https://bewww.cern.ch/ap/deployments/applications/cern/lhc/lhc-app-betabeating/PRO/BetaBeating-Control-3t.jnlp
+    javaws https://bewww.cern.ch/ap/deployments/applications/cern/lhc/lhc-app-beta-beating/PRO/BetaBeating-Control-3t.jnlp
     ```
     :material-arrow-right-bold: Disabling Java as it is too old and likely to be insecure. To reenable use jcontrol utility
 
 !!! success
     ```bash
-    /mcr/bin/jws https://bewww.cern.ch/ap/deployments/applications/cern/lhc/lhc-app-betabeating/PRO/BetaBeating-Control-3t.jnlp
+    /mcr/bin/jws https://bewww.cern.ch/ap/deployments/applications/cern/lhc/lhc-app-beta-beating/PRO/BetaBeating-Control-3t.jnlp
     ```
 
 #### Unspecific Error

--- a/docs/resources/links.md
+++ b/docs/resources/links.md
@@ -43,24 +43,24 @@
 
     _PRO_
     ```bash
-    jws https://bewww.cern.ch/ap/deployments/applications/cern/lhc/lhc-app-betabeating/PRO/BetaBeating-Control-3t.jnlp
+    jws https://bewww.cern.ch/ap/deployments/applications/cern/lhc/lhc-app-beta-beating/PRO/BetaBeating-Control-3t.jnlp
     ```
 
     _DEV_
     ```bash
-    jws https://bewww.cern.ch/ap/deployments-dev/applications/cern/lhc/lhc-app-betabeating/PRO/BetaBeating-Control-3t.jnlp
+    jws https://bewww.cern.ch/ap/deployments-dev/applications/cern/lhc/lhc-app-beta-beating/PRO/BetaBeating-Control-3t.jnlp
     ```
     
 === "Beta-Beat-OMC3"
 
     _PRO_
     ```bash
-    jws https://bewww.cern.ch/ap/deployments/applications/cern/lhc/lhc-app-betabeating-omc3/PRO/BetaBeatingOMC3-Control-3t.jnlp
+    jws https://bewww.cern.ch/ap/deployments/applications/cern/lhc/lhc-app-beta-beating-omc3/PRO/BetaBeatingOMC3-Control-3t.jnlp
     ```
 
     _DEV_
     ```bash
-    jws https://bewww.cern.ch/ap/deployments-dev/applications/cern/lhc/lhc-app-betabeating-omc3/PRO/BetaBeatingOMC3-Control-3t.jnlp
+    jws https://bewww.cern.ch/ap/deployments-dev/applications/cern/lhc/lhc-app-beta-beating-omc3/PRO/BetaBeatingOMC3-Control-3t.jnlp
     ```
 
 === "Kmod"


### PR DESCRIPTION
for some reason there was a `-` missing in the links to the GUIs jnlp, whenever it was shown how to run it (not in the direct links in the GUI section).

