### PR TITLE
RWS Local Coupling Procedure

### DIFF
--- a/docs/procedures/ampdet.md
+++ b/docs/procedures/ampdet.md
@@ -1,5 +1,12 @@
 # Amplitude Detuning Measurements
 
+!!! note ""
+    Please keep in mind the [general checks](general_checks.md) for measurements.
+
+??? info "The Procedure in Short"
+
+      Little bit about the purpose and concept.
+
 !!! warning "This is only an example procedure for demonstration purposes, to be written."
 
 ## Measurement

--- a/docs/procedures/kmod.md
+++ b/docs/procedures/kmod.md
@@ -1,7 +1,11 @@
 # Measuring $\beta^{*}$ Using K-Modulation in the LHC
 
-The important stuff.
-This decides over luminosity and lives in the experiments.
+!!! note ""
+    Please keep in mind the [general checks](general_checks.md) for measurements.
+
+??? info "The Procedure in Short"
+        The important stuff.
+        This decides over luminosity and lives in the experiments.
 
 ## Measurement
 

--- a/docs/procedures/rigid_waist_shift.md
+++ b/docs/procedures/rigid_waist_shift.md
@@ -25,12 +25,14 @@
 
 ## Procedure Per IP
 
+One should do this for earch of IP1, IP2, IP5 and IP8 which are the ones requiring local corrections.
+Keep in mind that this does beam 1 and 2 at the same time.
+
 !!! warning "Orbit Feedback"
       Please remember to **always** keep the orbit feedback system ON during this procedure.
 
 - [ ] <details class="nodeco"><summary>Trim in the Waist Shift Knob</summary>
       <p> Trim the prepared knob in the machine, for a certain direction (waist left/right of IP).
-      For knob preparation see with Felix S.
       Remember that this affects both beams at the same time.
       </p></details>
 
@@ -55,12 +57,17 @@
 
 - [ ] <details class="nodeco"><summary>Determine the Correction</summary>
       <p> Plot the evolution of the $|C^{-}|$ against the setting of the colinearity knob, and pick the setting that minimizes it.
+      The curves for each beam might not be minimized exactly around the same point, and a compromise may be needed.
       Eventually do a fit of the data to get a more accurate estimate of the correction.
       </p></details>
 
 - [ ] <details class="nodeco"><summary>**Optional:** Perform a Luminosity Scan of the Colinearity Knob</summary>
       <p> In commissioning and if conditions allow, one can validate and fine tune the correction with a luminosity scan.
       This has to be performed without a rigid waist shift.
+      </p></details>
+
+- [ ] <details class="nodeco"><summary>**Optional:** Do Global Corrections After Trimming</summary>
+      <p> One might want to do another round of global corrections, mainly coupling, after applying the determined colinearity knob setting.
       </p></details>
 
 *[MQSX]: The skew quadrupole correctors localed next to Q3

--- a/docs/procedures/rigid_waist_shift.md
+++ b/docs/procedures/rigid_waist_shift.md
@@ -5,12 +5,12 @@
 
 ??? info "The Procedure in Short"
 
-      This methods aims to find the MQSX correction settings that would minimize betatron coupling and its impact on beam size *at IP*.
+      This methods aims to find the MQSX correction settings that would minimize betatron coupling and its impact on beam size *at the IP*.
       The method breaks the symmetry of the optics in the IR and forces local coupling RDTs to leak throughout the machine, which makes them measurable through the $|C^{-}|$.
 
 
       After global corrections are done and trimmed in the machine, one applies a rigid waist shift in a given IR and scans the colinearity knob for the value that minimizes the $|C^{-}|$.
-      These settings, when taking away the rigid waist shift, will minimize local coupling and its impact at IP.
+      These settings, when taking away the rigid waist shift, will minimize local coupling and its impact at the IP.
 
 ## Preliminary Setup
 
@@ -26,13 +26,13 @@
 ## Procedure Per IP
 
 This procedure is applied at every experimental insertion (IR1, IR2, IR5, IR8) where local corrections need to be established or checked.
-Keep in mind that this does beam 1 and 2 at the same time, but different IPs cannot/ should not be done in parallel.
+Keep in mind that this does Beam1 and Beam2 at the same time, but different IPs cannot/ should not be done in parallel.
 
 !!! warning "Orbit Feedback"
-      Please remember to **always** keep the orbit feedback system ON during this procedure.
+      Please remember to **always** keep the orbit feedback system **ON** during this procedure.
 
 - [ ] <details class="nodeco"><summary>Trim in the Waist Shift Knob</summary>
-      <p> Trim the prepared knob in the machine, for a certain direction (waist left/right of IP).
+      <p> Trim the prepared knob in the machine, for a certain direction (waist left/right of the IP).
       Remember that this affects both beams at the same time.
       </p></details>
 
@@ -47,7 +47,7 @@ Keep in mind that this does beam 1 and 2 at the same time, but different IPs can
       </p></details>
 
 - [ ] <details class="nodeco"><summary>Trim in the Opposite Waist Shift Knob</summary>
-      <p> Trim the prepared knob in the machine, for the other direction (waist right/left of IP).
+      <p> Trim the prepared knob in the machine, for the other direction (waist right/left of the IP).
       </p></details>
 
 - [ ] <details class="nodeco"><summary>Scan the Colinearity Knob</summary>

--- a/docs/procedures/rigid_waist_shift.md
+++ b/docs/procedures/rigid_waist_shift.md
@@ -6,10 +6,10 @@
 ??? info "The Procedure in Short"
 
       This methods aims to find the MQSX correction settings that would minimize betatron coupling and its impact on beam size *at IP*.
-      The method breaks the symmetry of the optics in the IR and forces local coupling RDTs to leak thoughout the machine, which makes them measurable through the $|C^{-}|$.
+      The method breaks the symmetry of the optics in the IR and forces local coupling RDTs to leak throughout the machine, which makes them measurable through the $|C^{-}|$.
 
 
-      After global corrections are done and trimmed in the machine, one applies a rigid waist shift in a given IR and scans the colinearity knob for the value that minimises the $|C^{-}|$.
+      After global corrections are done and trimmed in the machine, one applies a rigid waist shift in a given IR and scans the colinearity knob for the value that minimizes the $|C^{-}|$.
       These settings, when taking away the rigid waist shift, will minimize local coupling and its impact at IP.
 
 ## Preliminary Setup
@@ -25,8 +25,8 @@
 
 ## Procedure Per IP
 
-One should do this for earch of IP1, IP2, IP5 and IP8 which are the ones requiring local corrections.
-Keep in mind that this does beam 1 and 2 at the same time.
+This procedure is applied at every experimental insertion (IR1, IR2, IR5, IR8) where local corrections need to be established or checked.
+Keep in mind that this does beam 1 and 2 at the same time, but different IPs cannot/ should not be done in parallel.
 
 !!! warning "Orbit Feedback"
       Please remember to **always** keep the orbit feedback system ON during this procedure.

--- a/docs/procedures/rigid_waist_shift.md
+++ b/docs/procedures/rigid_waist_shift.md
@@ -1,0 +1,70 @@
+# LHC Local Coupling Corrections with a Rigid Waist Shift
+
+!!! note ""
+    Please keep in mind the [general checks](general_checks.md) for measurements.
+
+??? info "The Procedure in Short"
+
+      This methods aims to find the MQSX correction settings that would minimize betatron coupling and its impact on beam size *at IP*.
+      The method breaks the symmetry of the optics in the IR and forces local coupling RDTs to leak thoughout the machine, which makes them measurable through the $|C^{-}|$.
+
+
+      After global corrections are done and trimmed in the machine, one applies a rigid waist shift in a given IR and scans the colinearity knob for the value that minimises the $|C^{-}|$.
+      These settings, when taking away the rigid waist shift, will minimize local coupling and its impact at IP.
+
+## Preliminary Setup
+
+- [ ] <details class="nodeco"><summary>Do Global Corrections</summary>
+      <p> This procedure needs global corrections to be trimmed in the machine first, so optics and *global* coupling should be taken care of beforehand.
+      </p></details>
+
+- [ ] <details class="nodeco"><summary>**Optional:** Scan the Colinearity Knob to Check Conditions</summary>
+      <p> If time allows, ideally we would scan the colinearity knob to ensure we see very small variations of the $|C^{-}|$.
+      If strong variations are noticed, then the expected conditions for the procedure are not met: either the phase advance between left and right MQSXs is off, or the $\sqrt{\beta_x \beta_y}$ is significantly wrong at these elements.
+      </p></details>
+
+## Procedure Per IP
+
+!!! warning "Orbit Feedback"
+      Please remember to **always** keep the orbit feedback system ON during this procedure.
+
+- [ ] <details class="nodeco"><summary>Trim in the Waist Shift Knob</summary>
+      <p> Trim the prepared knob in the machine, for a certain direction (waist left/right of IP).
+      For knob preparation see with Felix S.
+      Remember that this affects both beams at the same time.
+      </p></details>
+
+- [ ] <details class="nodeco"><summary>Scan the Colinearity Knob</summary>
+      <p> Trim the colinearity knob, about half a unit at a time.
+      For each setting, do some kicks and measure the $|C^{-}|$.
+      </p></details>
+
+- [ ] <details class="nodeco"><summary>Go Back to Nominal Machine</summary>
+      <p> Trim out the rigid waist shift, and ensure that no drift from nominal is observed.
+      If needed, do another round of global corrections.
+      </p></details>
+
+- [ ] <details class="nodeco"><summary>Trim in the Opposite Waist Shift Knob</summary>
+      <p> Trim the prepared knob in the machine, for the other direction (waist right/left of IP).
+      </p></details>
+
+- [ ] <details class="nodeco"><summary>Scan the Colinearity Knob</summary>
+      <p> Trim the colinearity knob, about half a unit at a time.
+      For each setting, do some kicks and measure the $|C^{-}|$.
+      </p></details>
+
+- [ ] <details class="nodeco"><summary>Determine the Correction</summary>
+      <p> Plot the evolution of the $|C^{-}|$ against the setting of the colinearity knob, and pick the setting that minimizes it.
+      Eventually do a fit of the data to get a more accurate estimate of the correction.
+      </p></details>
+
+- [ ] <details class="nodeco"><summary>**Optional:** Perform a Luminosity Scan of the Colinearity Knob</summary>
+      <p> In commissioning and if conditions allow, one can validate and fine tune the correction with a luminosity scan.
+      This has to be performed without a rigid waist shift.
+      </p></details>
+
+*[MQSX]: The skew quadrupole correctors localed next to Q3
+*[IP]: Interaction Point
+*[IR]: Insertion Region
+*[RDT]: Resonance Driving Terms
+*[Colinearity Knob]: This is a powering setting of the MQSXs, which corresponds to a K1S value of +/- 1E-4 m^-2.

--- a/docs/procedures/xing_scan.md
+++ b/docs/procedures/xing_scan.md
@@ -1,0 +1,7 @@
+# Crossing Angle Scans
+
+!!! note ""
+    Please keep in mind the [general checks](general_checks.md) for measurements.
+
+??? info "The Procedure in Short"
+      Little bit about the purpose and concept.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -177,6 +177,7 @@ nav:
       - Info: procedures/info.md
       - General Checks: procedures/general_checks.md
       - K Modulation: procedures/kmod.md
+      - Rigid Waist Shift: procedures/rigid_waist_shift.md
       - Amplitude Detuning: procedures/ampdet.md
       - Crossing Angle Scan: procedures/xing_scan.md
   - Resources:


### PR DESCRIPTION
This PR:
- Adds a procedure page for the local coupling correction with a rigid waist shift
- Adds a reminder to the `general checks` at the top of every procedure page
- Adds a small `info` admonition at the top of every procedure page, which should contain the gist of the procedure in a few words / sentences.