### PR TITLE
Change Jira links for Gitlab for BBGUI

### DIFF
--- a/docs/guis/betabeat/omc3.md
+++ b/docs/guis/betabeat/omc3.md
@@ -72,8 +72,8 @@ python -m omc3.module arg1 arg2 ...
 * Do NOT use the Nattune-Updater (in the Spectrum panel) if you have free kicks (it adds a `NATTUNE`-Column to the lin-file).
 
 !!! warning "Bug Reporting"
-    If you find bugs, please make [JIRA tickets][jira_bug_tickets]{target=_blank} with the `OMC3-GUI` label.
+    If you find bugs, please create [issues][betabeat_gui_gitlab_issues]{target=_blank} with the `OMC3-GUI` label.
 
 
 [omc3_github_getting_started]: https://github.com/pylhc/omc3#getting-started
-[jira_bug_tickets]: https://its.cern.ch/jira/projects/BBGUI/issues
+[betabeat_gui_gitlab_issues]: https://gitlab.cern.ch/acc-co/lhc/lhc-app-beta-beating/-/issues

--- a/docs/resources/links.md
+++ b/docs/resources/links.md
@@ -21,7 +21,7 @@
 === "Beta-Beat"
 
     * [Beta-Beat Gitlab][betabeat_gui_gitlab]{target=_blank .cern_login}
-    * [Jira Bugtracker][jira_bugtracker]{target=_blank .cern_login}
+    * [Beta-Beat Gitlab Issues][betabeat_gui_gitlab_issues]{target=_blank .cern_login}
     * [Artifactory][betabeat_artifactory]{target=_blank .cern_internal}
 
 === "Kmod"
@@ -167,7 +167,7 @@
 [omc_logos]: https://github.com/pylhc/pylhc.github.io/tree/master/docs/assets/logos
 
 [betabeat_gui_gitlab]: https://gitlab.cern.ch/acc-co/lhc/lhc-app-beta-beating
-[jira_bugtracker]: https://its.cern.ch/jira/projects/BBGUI/
+[betabeat_gui_gitlab_issues]: https://gitlab.cern.ch/acc-co/lhc/lhc-app-beta-beating/-/issues
 [betabeat_artifactory]: http://artifactory.cern.ch/webapp/#/artifacts/browse/tree/General/beco-release-local/cern/lhc/lhc-app-beta-beating
 
 [kmod_gui_gitlab]: https://gitlab.cern.ch/acc-co/lhc/lhc-app-kmod


### PR DESCRIPTION
The issues of the Beta-Beat GUI migrated to https://gitlab.cern.ch/acc-co/lhc/lhc-app-beta-beating/-/issues
This commit only updates the doc