### PR TITLE
Add documentation links for BBGUI

### DIFF
--- a/docs/guis/betabeat/gui.md
+++ b/docs/guis/betabeat/gui.md
@@ -4,6 +4,14 @@ The Beta-Beat GUI provides different functionalities separated in multiple views
 The GUI can be ran locally, provided you have access to `afs`, but most importantly directly from the CERN Control Center.
 This section provides a short overview for the main features.
 
+!!! info ""
+    The code documentation of the Beta-Beat GUI can be found on CERN's gitlab pages.
+    The master and OMC3 branches are generated:
+
+      * [Master branch][bbgui_doc_bbsrc]{target=_blank}
+      * [OMC3 branch][bbgui_doc_omc3]{target=_blank}
+
+
 The GUI provides several panels, each for a defined use and with a set of options and results:
 
 - [The BPM Panel](bpm_panel.md) for loading measurements files, displaying data and launching analysis.
@@ -13,3 +21,8 @@ The GUI provides several panels, each for a defined use and with a set of option
 
 This site will guide you through the GUI's layout and functionality.
 For starters, check out [the basics of running the GUI](../about.md).
+
+
+[bbgui_doc_bbsrc]: https://lhc-app-beta-beating.docs.cern.ch/master/
+[bbgui_doc_omc3]: https://lhc-app-beta-beating.docs.cern.ch/omc3/
+


### PR DESCRIPTION
Gitlab pages has been setup to generate the BBGUI doc for both master and OMC3 branches.
This commit adds the link to the `about` page of the BetaBeat GUI