### PR TITLE
fix missing semicolon in omc3 analysis

### DIFF
--- a/docs/packages/omc3/analysis.md
+++ b/docs/packages/omc3/analysis.md
@@ -64,7 +64,7 @@ In this walk-through, we will cover the use of the different entrypoints availab
     endmatch;
     
     ! ----- Slice Lattice for Tracking ----- !
-    slicefactor = 4    
+    slicefactor = 4;    
     call, file="/afs/cern.ch/eng/lhc/optics/runII/2018/toolkit/myslice.madx";  ! needs AFS access
     use, sequence=lhcb1;
     makethin, sequence=lhcb1, style=teapot, makedipedge=false;


### PR DESCRIPTION
Running the ` Generating the Example Data` script fails due to missing semicolon at the slice factor.
Additional error when cycling, but couldn't find out why.