### PR TITLE
Add 2023 commissioning logbook entries

### DIFF
--- a/docs/resources/logbook/2023_lhc.md
+++ b/docs/resources/logbook/2023_lhc.md
@@ -43,8 +43,8 @@ The tables below can be sorted by clicking next to the column headers.
 <!-- Tooltips -->
 *[Injection Linear Optics]:  Corrections with total phase-advance. DA comparison with MO and chroma (improved!). Injection optics with former (2021) corrections validated, fine corrections for normalized dispersion.
 *[Ramp and Squeeze Linear Optics]: Measurements and validation of optics from 200cm down to 30cm, including K-Mod. First new corrections at 120cm, applied from 200cm to 120cm. Bad IP8. All others agree well with corrections from the 2023 MD last year. 
-*[Measurements in the Ramp + Validation]: Measurements in the Ramp, Validation of 120cm optics with corrections done at 04-05 to lower IP8 beating. 
+*[Measurements in the Ramp + Validation]: Measurements in the Ramp, Validation of 120cm optics with corrections done on 2023-04-05 to lower IP8 beating. 
 *[a4 Corrections at 30cm]: Measurement of the f1012 and f1210 RDTs and corrections tests at 30cm. Some K-Mod measurement at 87cm.
 *[NL Studies at Injection]: Measurement of several RDTs with and without landau octupoles with both 2022 and 2023 optics.
-*[Ions Virgin + Local Coupling]: Get beams to end of ramp. Managed only after 2nd try (dump due to kick close to tune). Minor coupling correction.
+*[Ions Virgin + Local Coupling]: Get beams to end of ramp. Minor coupling correction.
 *[Ions Global Corr and Validation]: Implemented new local corrs at IP2. Trimmed energy to be the same as nominal. Calculated global corrs and re-measured.

--- a/docs/resources/logbook/2023_lhc.md
+++ b/docs/resources/logbook/2023_lhc.md
@@ -10,12 +10,17 @@ The tables below can be sorted by clicking next to the column headers.
     /afs/cern.ch/eng/sl/lintrack/LHC_commissioning2023/
     ```
     
-| Date       |     Type      |         Shift Purpose          |                                                             Logbook Link                                                              |
-| :--------- | :-----------: | :----------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------: |
-| 2023-03-28 | Commissioning |    Injection Linear Optics     |      [Shift Plan][inj_linear_optics]{target=\_blank .cern_login} /  [Summary][inj_linear_optics_sum]{target=\_blank .cern_login}      |
-| 2023-04-01 | Commissioning | Ramp and Squeeze Linear Optics | [Shift Plan][squeezed_linear_optics]{target=\_blank .cern_login} /  [Summary][squeezed_linear_optics_sum]{target=\_blank .cern_login} |
-| 2023-04-08 | Commissioning |     a4 Corrections at 30cm     |    [Shift Plan][a4_corrections_30cm]{target=\_blank .cern_login} /  [Summary][a4_corrections_30cm_sum]{target=\_blank .cern_login}    |
-| 2023-04-08 | Commissioning |    NL Studies at Injection     |   [Shift Plan][nl_studies_injection]{target=\_blank .cern_login} /  [Summary][nl_studies_injection_sum]{target=\_blank .cern_login}   |
+| Date       |     Type      |         Shift Purpose                 |                                                             Logbook Link                                                              |
+| :--------- | :-----------: | :-----------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------: |
+| 2023-03-28 | Commissioning |    Injection Linear Optics            |      [Shift Plan][inj_linear_optics]{target=\_blank .cern_login} /  [Summary][inj_linear_optics_sum]{target=\_blank .cern_login}      |
+| 2023-04-01 | Commissioning | Ramp and Squeeze Linear Optics        | [Shift Plan][squeezed_linear_optics]{target=\_blank .cern_login} /  [Summary][squeezed_linear_optics_sum]{target=\_blank .cern_login} |
+| 2023-04-06 | Commissioning | Measurements in the Ramp + Validation | [Shift Plan][meas_in_ramp]{target=\_blank .cern_login}           /  [Summary][meas_in_ramp_sum]{target=\_blank .cern_login}           |
+| 2023-04-08 | Commissioning |     a4 Corrections at 30cm            |    [Shift Plan][a4_corrections_30cm]{target=\_blank .cern_login} /  [Summary][a4_corrections_30cm_sum]{target=\_blank .cern_login}    |
+| 2023-04-08 | Commissioning |    NL Studies at Injection            |   [Shift Plan][nl_studies_injection]{target=\_blank .cern_login} /  [Summary][nl_studies_injection_sum]{target=\_blank .cern_login}   |
+| 2023-04-10 | Commissioning |    Ions Virgin + Local Coupling       |   [Entry][ions_virgin_coupl]{target=\_blank .cern_login}                                                                              |
+| 2023-04-16 | Commissioning |    Ions Global Corr and Validation    |   [Shift Plan][nl_studies_injection]{target=\_blank .cern_login} / [Summary][nl_studies_injection_sum]{target=\_blank .cern_login}    |
+
+
 
 
 <!-- All the links below -->
@@ -23,15 +28,23 @@ The tables below can be sorted by clicking next to the column headers.
 [inj_linear_optics_sum]:                    https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-03-29T00%3A00%3A00&dateTo=2023-03-29T23%3A59%3A59&eventToHighlight=3739271 
 [squeezed_linear_optics]:                   https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-01T00%3A00%3A00&dateTo=2023-04-01T23%3A59%3A59&eventToHighlight=3741499 
 [squeezed_linear_optics_sum]:               https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-04-01T00%3A00%3A00&dateTo=2023-04-01T23%3A59%3A59&eventToHighlight=3741722
+[meas_in_ramp]:                             https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-04-06T00%3A00%3A00&dateTo=2023-04-06T23%3A59%3A59&eventToHighlight=3744741 
+[meas_in_ramp_sum]:                         https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-04-06T00%3A00%3A00&dateTo=2023-04-06T23%3A59%3A59&eventToHighlight=3744954 
 [a4_corrections_30cm]:                      https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745378
 [a4_corrections_30cm_sum]:                  https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745433
 [nl_studies_injection]:                     https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745829
 [nl_studies_injection_sum]:                 https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-04-08T23%3A00%3A00&dateTo=2023-04-09T07%3A00%3A00&eventToHighlight=3746004
+[ions_virgin_coupl]:                        https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-10T00%3A00%3A00&dateTo=2023-04-10T23%3A59%3A59&eventToHighlight=3746402
+[nl_studies_injection]:                     https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-16T00%3A00%3A00&dateTo=2023-04-16T23%3A59%3A59&eventToHighlight=3751170
+[nl_studies_injection_sum]:                 https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-16T00%3A00%3A00&dateTo=2023-04-16T23%3A59%3A59&eventToHighlight=3751258
 
 
 
 <!-- Tooltips -->
 *[Injection Linear Optics]:  Corrections with total phase-advance. DA comparison with MO and chroma (improved!). Injection optics with former (2021) corrections validated, fine corrections for normalized dispersion.
-*[Ramp and Squeeze Linear Optics]: Measurements and validation of optics from 200cm down to 30cm, including K-Mod. New corrections at 120cm. All others agree well with corrections from the 2023 MD last year. 
+*[Ramp and Squeeze Linear Optics]: Measurements and validation of optics from 200cm down to 30cm, including K-Mod. First new corrections at 120cm, applied from 200cm to 120cm. Bad IP8. All others agree well with corrections from the 2023 MD last year. 
+*[Measurements in the Ramp + Validation]: Measurements in the Ramp, Validation of 120cm optics with corrections done at 04-05 to lower IP8 beating. 
 *[a4 Corrections at 30cm]: Measurement of the f1012 and f1210 RDTs and corrections tests at 30cm. Some K-Mod measurement at 87cm.
 *[NL Studies at Injection]: Measurement of several RDTs with and without landau octupoles with both 2022 and 2023 optics.
+*[Ions Virgin + Local Coupling]: Get beams to end of ramp. Managed only after 2nd try (dump due to kick close to tune). Minor coupling correction.
+*[Ions Global Corr and Validation]: Implemented new local corrs at IP2. Trimmed energy to be the same as nominal. Calculated global corrs and re-measured.

--- a/docs/resources/logbook/2023_lhc.md
+++ b/docs/resources/logbook/2023_lhc.md
@@ -28,8 +28,8 @@ The tables below can be sorted by clicking next to the column headers.
 [inj_linear_optics_sum]:                    https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-03-29T00%3A00%3A00&dateTo=2023-03-29T23%3A59%3A59&eventToHighlight=3739271 
 [squeezed_linear_optics]:                   https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-01T00%3A00%3A00&dateTo=2023-04-01T23%3A59%3A59&eventToHighlight=3741499 
 [squeezed_linear_optics_sum]:               https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-04-01T00%3A00%3A00&dateTo=2023-04-01T23%3A59%3A59&eventToHighlight=3741722
-[meas_in_ramp]:                             https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-04-06T00%3A00%3A00&dateTo=2023-04-06T23%3A59%3A59&eventToHighlight=3744741 
-[meas_in_ramp_sum]:                         https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-04-06T00%3A00%3A00&dateTo=2023-04-06T23%3A59%3A59&eventToHighlight=3744954 
+[meas_in_ramp]:                             https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-06T00%3A00%3A00&dateTo=2023-04-06T23%3A59%3A59&eventToHighlight=3744741 
+[meas_in_ramp_sum]:                         https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-06T00%3A00%3A00&dateTo=2023-04-06T23%3A59%3A59&eventToHighlight=3744954 
 [a4_corrections_30cm]:                      https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745378
 [a4_corrections_30cm_sum]:                  https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745433
 [nl_studies_injection]:                     https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745829

--- a/docs/resources/logbook/2023_lhc.md
+++ b/docs/resources/logbook/2023_lhc.md
@@ -10,14 +10,14 @@ The tables below can be sorted by clicking next to the column headers.
     /afs/cern.ch/eng/sl/lintrack/LHC_commissioning2023/
     ```
     
-| Date       |     Type      |         Shift Purpose                 |                                                             Logbook Link                                                              |
+| Date       |     Type      |             Shift Purpose             |                                                             Logbook Link                                                              |
 | :--------- | :-----------: | :-----------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------: |
-| 2023-03-28 | Commissioning |    Injection Linear Optics            |      [Shift Plan][inj_linear_optics]{target=\_blank .cern_login} /  [Summary][inj_linear_optics_sum]{target=\_blank .cern_login}      |
-| 2023-04-01 | Commissioning | Ramp and Squeeze Linear Optics        | [Shift Plan][squeezed_linear_optics]{target=\_blank .cern_login} /  [Summary][squeezed_linear_optics_sum]{target=\_blank .cern_login} |
-| 2023-04-06 | Commissioning | Measurements in the Ramp + Validation | [Shift Plan][meas_in_ramp]{target=\_blank .cern_login}           /  [Summary][meas_in_ramp_sum]{target=\_blank .cern_login}           |
-| 2023-04-08 | Commissioning |     a4 Corrections at 30cm            |    [Shift Plan][a4_corrections_30cm]{target=\_blank .cern_login} /  [Summary][a4_corrections_30cm_sum]{target=\_blank .cern_login}    |
-| 2023-04-08 | Commissioning |    NL Studies at Injection            |   [Shift Plan][nl_studies_injection]{target=\_blank .cern_login} /  [Summary][nl_studies_injection_sum]{target=\_blank .cern_login}   |
-| 2023-04-10 | Commissioning |    Ions Virgin + Local Coupling       |   [Entry][ions_virgin_coupl]{target=\_blank .cern_login}                                                                              |
+| 2023-03-28 | Commissioning |        Injection Linear Optics        |      [Shift Plan][inj_linear_optics]{target=\_blank .cern_login} /  [Summary][inj_linear_optics_sum]{target=\_blank .cern_login}      |
+| 2023-04-01 | Commissioning |    Ramp and Squeeze Linear Optics     | [Shift Plan][squeezed_linear_optics]{target=\_blank .cern_login} /  [Summary][squeezed_linear_optics_sum]{target=\_blank .cern_login} |
+| 2023-04-06 | Commissioning | Measurements in the Ramp + Validation |      [Shift Plan][meas_in_ramp]{target=\_blank .cern_login}           /  [Summary][meas_in_ramp_sum]{target=\_blank .cern_login}      |
+| 2023-04-08 | Commissioning |        a4 Corrections at 30cm         |    [Shift Plan][a4_corrections_30cm]{target=\_blank .cern_login} /  [Summary][a4_corrections_30cm_sum]{target=\_blank .cern_login}    |
+| 2023-04-08 | Commissioning |        NL Studies at Injection        |   [Shift Plan][nl_studies_injection]{target=\_blank .cern_login} /  [Summary][nl_studies_injection_sum]{target=\_blank .cern_login}   |
+| 2023-04-10 | Commissioning |     Ions Virgin + Local Coupling      |                                        [Entry][ions_virgin_coupl]{target=\_blank .cern_login}                                         |
 | 2023-04-16 | Commissioning |    Ions Global Corr and Validation    |   [Shift Plan][nl_studies_injection]{target=\_blank .cern_login} / [Summary][nl_studies_injection_sum]{target=\_blank .cern_login}    |
 
 
@@ -29,7 +29,7 @@ The tables below can be sorted by clicking next to the column headers.
 [squeezed_linear_optics]:                   https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-01T00%3A00%3A00&dateTo=2023-04-01T23%3A59%3A59&eventToHighlight=3741499 
 [squeezed_linear_optics_sum]:               https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-04-01T00%3A00%3A00&dateTo=2023-04-01T23%3A59%3A59&eventToHighlight=3741722
 [meas_in_ramp]:                             https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-06T00%3A00%3A00&dateTo=2023-04-06T23%3A59%3A59&eventToHighlight=3744741 
-[meas_in_ramp_sum]:                         https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-06T00%3A00%3A00&dateTo=2023-04-06T23%3A59%3A59&eventToHighlight=3744954 
+[meas_in_ramp_sum]:                         https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-07T00%3A00%3A00&dateTo=2023-04-07T23%3A59%3A59&eventToHighlight=3744954 
 [a4_corrections_30cm]:                      https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745378
 [a4_corrections_30cm_sum]:                  https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745433
 [nl_studies_injection]:                     https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745829

--- a/docs/resources/logbook/2023_lhc.md
+++ b/docs/resources/logbook/2023_lhc.md
@@ -17,8 +17,8 @@ The tables below can be sorted by clicking next to the column headers.
 | 2023-04-06 | Commissioning | Measurements in the Ramp + Validation |      [Shift Plan][meas_in_ramp]{target=\_blank .cern_login}           /  [Summary][meas_in_ramp_sum]{target=\_blank .cern_login}      |
 | 2023-04-08 | Commissioning |        a4 Corrections at 30cm         |    [Shift Plan][a4_corrections_30cm]{target=\_blank .cern_login} /  [Summary][a4_corrections_30cm_sum]{target=\_blank .cern_login}    |
 | 2023-04-08 | Commissioning |        NL Studies at Injection        |   [Shift Plan][nl_studies_injection]{target=\_blank .cern_login} /  [Summary][nl_studies_injection_sum]{target=\_blank .cern_login}   |
-| 2023-04-10 | Commissioning |     Ions Virgin + Local Coupling      |                                        [Entry][ions_virgin_coupl]{target=\_blank .cern_login}                                         |
-| 2023-04-16 | Commissioning |    Ions Global Corr and Validation    |   [Shift Plan][nl_studies_injection]{target=\_blank .cern_login} / [Summary][nl_studies_injection_sum]{target=\_blank .cern_login}    |
+| 2023-04-10 | Commissioning |          Ions Virgin Optics           |                                        [Entry][ions_virgin_coupl]{target=\_blank .cern_login}                                         |
+| 2023-04-16 | Commissioning |        Ions Optics Validation         |   [Shift Plan][nl_studies_injection]{target=\_blank .cern_login} / [Summary][nl_studies_injection_sum]{target=\_blank .cern_login}    |
 
 
 
@@ -34,7 +34,7 @@ The tables below can be sorted by clicking next to the column headers.
 [a4_corrections_30cm_sum]:                  https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745433
 [nl_studies_injection]:                     https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745829
 [nl_studies_injection_sum]:                 https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-04-08T23%3A00%3A00&dateTo=2023-04-09T07%3A00%3A00&eventToHighlight=3746004
-[ions_virgin_coupl]:                        https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-10T00%3A00%3A00&dateTo=2023-04-10T23%3A59%3A59&eventToHighlight=3746402
+[ions_virgin_coupl]:                        https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-10T00%3A00%3A00&dateTo=2023-04-10T23%3A59%3A59&eventToHighlight=3746422
 [nl_studies_injection]:                     https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-16T00%3A00%3A00&dateTo=2023-04-16T23%3A59%3A59&eventToHighlight=3751170
 [nl_studies_injection_sum]:                 https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-16T00%3A00%3A00&dateTo=2023-04-16T23%3A59%3A59&eventToHighlight=3751258
 
@@ -46,5 +46,5 @@ The tables below can be sorted by clicking next to the column headers.
 *[Measurements in the Ramp + Validation]: Measurements in the Ramp, Validation of 120cm optics with corrections done on 2023-04-05 to lower IP8 beating. 
 *[a4 Corrections at 30cm]: Measurement of the f1012 and f1210 RDTs and corrections tests at 30cm. Some K-Mod measurement at 87cm.
 *[NL Studies at Injection]: Measurement of several RDTs with and without landau octupoles with both 2022 and 2023 optics.
-*[Ions Virgin + Local Coupling]: Get beams to end of ramp. Minor coupling correction.
-*[Ions Global Corr and Validation]: Implemented new local corrs at IP2. Trimmed energy to be the same as nominal. Calculated global corrs and re-measured.
+*[Ions Virgin Optics]: Got ions optics to 50cm at IP2. Minor local coupling correction attempted, not very convincing. This is poorly documented in the logbook.
+*[Ions Optics Validation]: Implemented new local corrs at IP2. Trimmed energy to be the same as nominal. Calculated global corrections and re-measured for validation.


### PR DESCRIPTION
- some minor corrections to existing entries
- added days 04-06 (validation of new 120cm corrs), 04-10, 04-16 (both Ions)