### PR TITLE
High Beta shift to logbook

### DIFF
--- a/docs/resources/logbook/2023_lhc.md
+++ b/docs/resources/logbook/2023_lhc.md
@@ -18,26 +18,27 @@ The tables below can be sorted by clicking next to the column headers.
 | 2023-04-08 | Commissioning |        a4 Corrections at 30cm         |    [Shift Plan][a4_corrections_30cm]{target=\_blank .cern_login} /  [Summary][a4_corrections_30cm_sum]{target=\_blank .cern_login}    |
 | 2023-04-08 | Commissioning |        NL Studies at Injection        |   [Shift Plan][nl_studies_injection]{target=\_blank .cern_login} /  [Summary][nl_studies_injection_sum]{target=\_blank .cern_login}   |
 | 2023-04-10 | Commissioning |          Ions Virgin Optics           |                                        [Entry][ions_virgin_coupl]{target=\_blank .cern_login}                                         |
-| 2023-04-16 | Commissioning |        Ions Optics Validation         |   [Shift Plan][nl_studies_injection]{target=\_blank .cern_login} / [Summary][nl_studies_injection_sum]{target=\_blank .cern_login}    |
-
+| 2023-04-16 | Commissioning |        Ions Optics Validation         |             [Shift Plan][ion_optics]{target=\_blank .cern_login} / [Summary][ion_optics_sum]{target=\_blank .cern_login}              |
+| 2023-04-16 | Commissioning |      High Beta Optics Validation      |        [Shift Plan][high_beta_shift]{target=\_blank .cern_login} / [Summary][high_beta_shift_sum]{target=\_blank .cern_login}         |
 
 
 
 <!-- All the links below -->
-[inj_linear_optics]:                        https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-03-28T00%3A00%3A00&dateTo=2023-03-28T23%3A59%3A59&eventToHighlight=3739094 
-[inj_linear_optics_sum]:                    https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-03-29T00%3A00%3A00&dateTo=2023-03-29T23%3A59%3A59&eventToHighlight=3739271 
-[squeezed_linear_optics]:                   https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-01T00%3A00%3A00&dateTo=2023-04-01T23%3A59%3A59&eventToHighlight=3741499 
-[squeezed_linear_optics_sum]:               https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-04-01T00%3A00%3A00&dateTo=2023-04-01T23%3A59%3A59&eventToHighlight=3741722
-[meas_in_ramp]:                             https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-06T00%3A00%3A00&dateTo=2023-04-06T23%3A59%3A59&eventToHighlight=3744741 
-[meas_in_ramp_sum]:                         https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-07T00%3A00%3A00&dateTo=2023-04-07T23%3A59%3A59&eventToHighlight=3744954 
-[a4_corrections_30cm]:                      https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745378
-[a4_corrections_30cm_sum]:                  https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745433
-[nl_studies_injection]:                     https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745829
-[nl_studies_injection_sum]:                 https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-04-08T23%3A00%3A00&dateTo=2023-04-09T07%3A00%3A00&eventToHighlight=3746004
-[ions_virgin_coupl]:                        https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-10T00%3A00%3A00&dateTo=2023-04-10T23%3A59%3A59&eventToHighlight=3746422
-[nl_studies_injection]:                     https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-16T00%3A00%3A00&dateTo=2023-04-16T23%3A59%3A59&eventToHighlight=3751170
-[nl_studies_injection_sum]:                 https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-16T00%3A00%3A00&dateTo=2023-04-16T23%3A59%3A59&eventToHighlight=3751258
-
+[inj_linear_optics]:           https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-03-28T00%3A00%3A00&dateTo=2023-03-28T23%3A59%3A59&eventToHighlight=3739094 
+[inj_linear_optics_sum]:       https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-03-29T00%3A00%3A00&dateTo=2023-03-29T23%3A59%3A59&eventToHighlight=3739271 
+[squeezed_linear_optics]:      https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-01T00%3A00%3A00&dateTo=2023-04-01T23%3A59%3A59&eventToHighlight=3741499 
+[squeezed_linear_optics_sum]:  https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-04-01T00%3A00%3A00&dateTo=2023-04-01T23%3A59%3A59&eventToHighlight=3741722
+[meas_in_ramp]:                https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-06T00%3A00%3A00&dateTo=2023-04-06T23%3A59%3A59&eventToHighlight=3744741 
+[meas_in_ramp_sum]:            https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-07T00%3A00%3A00&dateTo=2023-04-07T23%3A59%3A59&eventToHighlight=3744954 
+[a4_corrections_30cm]:         https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745378
+[a4_corrections_30cm_sum]:     https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745433
+[nl_studies_injection]:        https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-08T00%3A00%3A00&dateTo=2023-04-08T23%3A59%3A59&eventToHighlight=3745829
+[nl_studies_injection_sum]:    https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=322&dateFrom=2023-04-08T23%3A00%3A00&dateTo=2023-04-09T07%3A00%3A00&eventToHighlight=3746004
+[ions_virgin_coupl]:           https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-10T00%3A00%3A00&dateTo=2023-04-10T23%3A59%3A59&eventToHighlight=3746422
+[ion_optics]:                  https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-16T00%3A00%3A00&dateTo=2023-04-16T23%3A59%3A59&eventToHighlight=3751170
+[ion_optics_sum]:              https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-04-16T00%3A00%3A00&dateTo=2023-04-16T23%3A59%3A59&eventToHighlight=3751258
+[high_beta_shift]:             https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-06-08T00%3A00%3A00&dateTo=2023-06-08T23%3A59%3A59&eventToHighlight=3782032
+[high_beta_shift_sum]:         https://be-op-logbook.web.cern.ch/elogbook-server/#/logbook?logbookId=1081&dateFrom=2023-06-08T00%3A00%3A00&dateTo=2023-06-08T23%3A59%3A59&eventToHighlight=3782115
 
 
 <!-- Tooltips -->
@@ -48,3 +49,4 @@ The tables below can be sorted by clicking next to the column headers.
 *[NL Studies at Injection]: Measurement of several RDTs with and without landau octupoles with both 2022 and 2023 optics.
 *[Ions Virgin Optics]: Got ions optics to 50cm at IP2. Minor local coupling correction attempted, not very convincing. This is poorly documented in the logbook.
 *[Ions Optics Validation]: Implemented new local corrs at IP2. Trimmed energy to be the same as nominal. Calculated global corrections and re-measured for validation.
+*[High Beta Optics Validation]: Measured and validated high beta optics (120m). Did some global corrections, beta-beating below 4% in the end. K-mod done but not used.


### PR DESCRIPTION
Closes #98

Also fixes a copy-paste error in the links for the ion optics, which had overriden a previous alias and had the NL injection links pointing to the wrong place.