### PR TITLE
Include opt-in edit button

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ theme:
   features:
     - navigation.tabs
     - navigation.instant
+    - content.action.edit  # editing button on the pages is opt-in since v9
   palette:
     scheme: preference
     primary: indigo


### PR DESCRIPTION
The "edit page" button is opt-in since v9.
This PR adds the configuration to keep it.

See https://github.com/squidfunk/mkdocs-material/issues/5261