### PR TITLE
User guide updates temp warnings

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -83,6 +83,11 @@ a.cern_internal {
     border-left: none;
 }
 
+/* Specific style for warning admonitions */
+.md-typeset .admonition.warning {
+    font-size: 0.74rem !important; /* make warning text larger, default: 0.64 */
+}
+
 .md-typeset .nodeco > .admonition-title::before,
 .md-typeset .nodeco > summary::before {
   height: 0;  /* hides icon */

--- a/docs/guis/betabeat/ampdet.md
+++ b/docs/guis/betabeat/ampdet.md
@@ -1,1 +1,4 @@
 # Amplitude Detuning Analysis
+
+!!! warning "Incomplete"
+    This page is a placeholder and is not yet complete.

--- a/docs/guis/betabeat/correction_panel.md
+++ b/docs/guis/betabeat/correction_panel.md
@@ -1,4 +1,8 @@
-# The Beta-Beat GUI Correction Panel
+# The Correction Panel
+
+!!! warning "Incomplete"
+    This page is a placeholder and is not yet complete.
+    Information here is outdated and needs to be revised for the `omc3` version of the Beta-Beat GUI.
 
 The `Correction` panel displays the corrections computed from the `Optics` panel to bring back the measured machine to nominal model conditions.
 

--- a/docs/guis/betabeat/optics_panel.md
+++ b/docs/guis/betabeat/optics_panel.md
@@ -1,4 +1,8 @@
-# The Beta-Beat GUI Optics Panel
+# The Optics Panel
+
+!!! warning "Incomplete"
+    This page is a placeholder and is not yet complete.
+    Information here is outdated and needs to be revised for the `omc3` version of the Beta-Beat GUI.
 
 The `Optics Panel` provides graphical interface to compare the computed optics to the nominal model.
 There are in total three main tabs for the optics panel:


### PR DESCRIPTION
Added warnings to the remaining pages: optics panel, correction panel, amplitude detuning panel.

I also increased the size of the warning admonitions in general a tiny bit to make them stand out more.

Hint for @jgray-19 : I suggested to merge the user_guide_updates branch already into master as people might already profit from it.